### PR TITLE
Optimization: Shared allocator without mutex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ zig-out
 TODO
 bench*
 grow_shrink_bench*
+.aider*

--- a/build.zig
+++ b/build.zig
@@ -63,6 +63,7 @@ pub fn build(b: *std.Build) !void {
         .root_source_file = b.path("src/jdz_allocator.zig"),
         .target = target,
         .optimize = optimize,
+        .sanitize_thread = true
     });
 
     const run_tests = b.addRunArtifact(tests);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "jdz_allocator",
-    .version = "0.2.1",
+    .version = "0.2.2",
     .dependencies = .{},
     .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "jdz_allocator",
-    .version = "0.2.2",
+    .name = .jdz_allocator,
+    .fingerprint = 0x6f68fb3d5e800f0d,
+    .version = "0.2.3",
     .dependencies = .{},
     .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "jdz_allocator",
-    .version = "0.2.0",
+    .version = "0.2.1",
     .dependencies = .{},
     .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "jdz_allocator",
-    .version = "0.1.0",
+    .name = .jdz_allocator,
+    .version = "0.1.1",
+    .fingerprint = 0x6f68fb3da6743e31,
     .dependencies = .{},
     .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "jdz_allocator",
-    .version = "0.1.0",
+    .version = "0.2.0",
     .dependencies = .{},
     .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "jdz_allocator",
-    .version = "0.0.3",
+    .version = "0.1.0",
     .dependencies = .{},
     .paths = .{""},
 }

--- a/libso/libjdzglobal.zig
+++ b/libso/libjdzglobal.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const jdz_allocator = @import("jdz_allocator");
 
-const assert = std.assert;
 const log = std.log.scoped(.jdz_allocator);
 
 const JdzGlobalAllocator = jdz_allocator.JdzGlobalAllocator(.{});
@@ -90,13 +89,13 @@ export fn memalign(alignment: usize, size: usize) ?*anyopaque {
 
 export fn valloc(size: usize) ?*anyopaque {
     log.debug("valloc {d}", .{size});
-    return allocateBytes(size, std.mem.page_size, @returnAddress(), false, false, true);
+    return allocateBytes(size, std.heap.pageSize(), @returnAddress(), false, false, true);
 }
 
 export fn pvalloc(size: usize) ?*anyopaque {
     log.debug("pvalloc {d}", .{size});
-    const aligned_size = std.mem.alignForward(usize, size, std.mem.page_size);
-    return allocateBytes(aligned_size, std.mem.page_size, @returnAddress(), false, false, true);
+    const aligned_size = std.mem.alignForward(usize, size, std.heap.pageSize());
+    return allocateBytes(aligned_size, std.heap.pageSize(), @returnAddress(), false, false, true);
 }
 
 export fn malloc_usable_size(ptr_opt: ?*anyopaque) usize {
@@ -129,7 +128,7 @@ fn allocateBytes(
     }
 
     const log2_align = std.math.log2_int(usize, alignment);
-    if (allocator.rawAlloc(byte_count, log2_align, ret_addr)) |ptr| {
+    if (allocator.rawAlloc(byte_count, @enumFromInt(log2_align), ret_addr)) |ptr| {
         @memset(ptr[0..byte_count], if (zero) 0 else undefined);
         log.debug("allocated {*}", .{ptr});
         return ptr;

--- a/libso/libjdzshared.zig
+++ b/libso/libjdzshared.zig
@@ -1,11 +1,10 @@
 const std = @import("std");
 const jdz_allocator = @import("jdz_allocator");
 
-const assert = std.assert;
 const log = std.log.scoped(.jdz_allocator);
 
 var allocator_instance = jdz_allocator.JdzAllocator(.{}).init();
-var allocator = allocator_instance.allocator();
+const allocator = allocator_instance.allocator();
 
 ///
 /// Slightly modified copy of https://github.com/dweiller/zimalloc/blob/main/src/libzimalloc.zig
@@ -55,7 +54,9 @@ export fn free(ptr_opt: ?*anyopaque) void {
 export fn calloc(size: usize, count: usize) ?*anyopaque {
     log.debug("calloc {d} {d}", .{ size, count });
     const bytes = size * count;
-    return allocateBytes(bytes, 1, @returnAddress(), true, false, true);
+    const data = allocateBytes(bytes, 1, @returnAddress(), true, false, true) orelse return null;
+    @memset(data[0..bytes], 0);
+    return data;
 }
 
 export fn aligned_alloc(alignment: usize, size: usize) ?*anyopaque {
@@ -90,13 +91,13 @@ export fn memalign(alignment: usize, size: usize) ?*anyopaque {
 
 export fn valloc(size: usize) ?*anyopaque {
     log.debug("valloc {d}", .{size});
-    return allocateBytes(size, std.mem.page_size, @returnAddress(), false, false, true);
+    return allocateBytes(size, std.heap.pageSize(), @returnAddress(), false, false, true);
 }
 
 export fn pvalloc(size: usize) ?*anyopaque {
     log.debug("pvalloc {d}", .{size});
-    const aligned_size = std.mem.alignForward(usize, size, std.mem.page_size);
-    return allocateBytes(aligned_size, std.mem.page_size, @returnAddress(), false, false, true);
+    const aligned_size = std.mem.alignForward(usize, size, std.heap.pageSize());
+    return allocateBytes(aligned_size, std.heap.pageSize(), @returnAddress(), false, false, true);
 }
 
 export fn malloc_usable_size(ptr_opt: ?*anyopaque) usize {
@@ -125,7 +126,7 @@ fn allocateBytes(
     }
 
     const log2_align = std.math.log2_int(usize, alignment);
-    if (allocator.rawAlloc(byte_count, log2_align, ret_addr)) |ptr| {
+    if (allocator.rawAlloc(byte_count, @enumFromInt(log2_align), ret_addr)) |ptr| {
         @memset(ptr[0..byte_count], if (zero) 0 else undefined);
         log.debug("allocated {*}", .{ptr});
         return ptr;

--- a/src/DeferredSpanList.zig
+++ b/src/DeferredSpanList.zig
@@ -6,7 +6,7 @@ const span_file = @import("span.zig");
 const Span = span_file.Span;
 const JdzAllocConfig = jdz_allocator.JdzAllocConfig;
 const testing = std.testing;
-const assert = std.debug.assert;
+const assert = utils.assert;
 
 head: ?*Span = null,
 

--- a/src/SpanList.zig
+++ b/src/SpanList.zig
@@ -7,7 +7,7 @@ const span_file = @import("span.zig");
 const Span = span_file.Span;
 const JdzAllocConfig = jdz_allocator.JdzAllocConfig;
 const testing = std.testing;
-const assert = std.debug.assert;
+const assert = utils.assert;
 
 head: ?*Span = null,
 tail: ?*Span = null,

--- a/src/arena.zig
+++ b/src/arena.zig
@@ -157,7 +157,7 @@ pub fn Arena(comptime config: JdzAllocConfig, comptime is_threadlocal: bool) typ
         }
 
         fn allocateFromCacheOrNew(self: *Self, size_class: SizeClass) ?[*]u8 {
-            const span = self.getSpanFromCacheOrNew() orelse return null;
+            const span: *Span = self.getSpanFromCacheOrNew() orelse return null;
 
             span.initialiseFreshSpan(self, size_class);
 

--- a/src/arena.zig
+++ b/src/arena.zig
@@ -616,19 +616,24 @@ pub fn Arena(comptime config: JdzAllocConfig, comptime is_threadlocal: bool) typ
         }
 
         inline fn freeSmallOrMediumShared(self: *Self, span: *Span, buf: []u8) void {
-            const tid = @call(.always_inline, getThreadId, .{});
+            // I didn't read completly this file so ... Later i will take a proper look
+            // and see if i can optimize something. I just wanted to keep this code
+            //
+            // const tid = @call(.always_inline, getThreadId, .{});
 
-            if (self.thread_id == tid and @call(.always_inline, Self.tryAcquire, .{self})) {
-                defer @call(.always_inline, Self.release, .{self});
+            // if (self.thread_id == tid and @call(.always_inline, Self.tryAcquire, .{self})) {
+            //     defer @call(.always_inline, Self.release, .{self});
 
-                @call(.always_inline, Span.pushFreeList, .{ span, buf });
+            //     @call(.always_inline, Span.pushFreeList, .{ span, buf });
 
-                @call(.always_inline, handleSpanNoLongerFull, .{ self, span });
-            } else {
-                @call(.always_inline, Span.pushDeferredFreeList, .{ span, buf });
+            //     @call(.always_inline, handleSpanNoLongerFull, .{ self, span });
+            // } else {
+            //     @call(.always_inline, Span.pushDeferredFreeList, .{ span, buf });
 
-                @call(.always_inline, handleSpanNoLongerFullDeferred, .{ self, span });
-            }
+            //     @call(.always_inline, handleSpanNoLongerFullDeferred, .{ self, span });
+            // }
+            @call(.always_inline, Span.pushFreeList, .{ span, buf });
+            @call(.always_inline, handleSpanNoLongerFull, .{ self, span });
         }
 
         inline fn handleSpanNoLongerFull(self: *Self, span: *Span) void {

--- a/src/arena.zig
+++ b/src/arena.zig
@@ -63,9 +63,9 @@ pub fn Arena(comptime config: JdzAllocConfig, comptime is_threadlocal: bool) typ
 
             return .{
                 .backing_allocator = config.backing_allocator,
-                .spans = .{.{}} ** size_class_count,
-                .free_lists = .{@constCast(&free_list_null)} ** size_class_count,
-                .deferred_partial_spans = .{.{}} ** size_class_count,
+                .spans = @splat(SpanList{}),
+                .free_lists = @splat(@constCast(&free_list_null)),
+                .deferred_partial_spans = @splat(DeferredSpanList{}),
                 .span_count = Value(usize).init(0),
                 .cache = ArenaSpanCache.init(),
                 .large_cache = large_cache,

--- a/src/arena.zig
+++ b/src/arena.zig
@@ -66,9 +66,9 @@ pub fn Arena(comptime config: JdzAllocConfig, comptime is_threadlocal: bool) typ
 
             return .{
                 .backing_allocator = config.backing_allocator,
-                .spans = .{.{}} ** size_class_count,
-                .free_lists = .{@constCast(&free_list_null)} ** size_class_count,
-                .deferred_partial_spans = .{.{}} ** size_class_count,
+                .spans = @splat(SpanList{}),
+                .free_lists = @splat(@constCast(&free_list_null)),
+                .deferred_partial_spans = @splat(DeferredSpanList{}),
                 .span_count = Value(usize).init(0),
                 .cache = ArenaSpanCache.init(),
                 .large_cache = large_cache,

--- a/src/arena.zig
+++ b/src/arena.zig
@@ -49,7 +49,7 @@ pub fn Arena(comptime config: JdzAllocConfig, comptime is_threadlocal: bool) typ
         const Self = @This();
 
         pub fn init() Self {
-            @setEvalBranchQuota(4 * @as(u32, large_class_count) * @max(config.map_cache_limit, config.large_cache_limit));
+            @setEvalBranchQuota(32 * @as(u32, large_class_count) * @max(config.map_cache_limit, config.large_cache_limit));
             var large_cache: [large_class_count]ArenaLargeCache = undefined;
             var map_cache: [large_class_count]ArenaMapCache = undefined;
 

--- a/src/arena.zig
+++ b/src/arena.zig
@@ -622,14 +622,14 @@ pub fn Arena(comptime config: JdzAllocConfig, comptime is_threadlocal: bool) typ
         }
 
         inline fn handleSpanNoLongerFull(self: *Self, span: *Span) void {
-            if (span.full and @atomicRmw(bool, &span.full, .Xchg, false, .monotonic)) {
+            if (span.full and @atomicRmw(bool, &span.full, .Xchg, false, .acq_rel)) {
                 self.spans[span.class.class_idx].write(span);
                 self.free_lists[span.class.class_idx] = self.spans[span.class.class_idx].getHeadFreeList();
             }
         }
 
         inline fn handleSpanNoLongerFullDeferred(self: *Self, span: *Span) void {
-            if (span.full and @atomicRmw(bool, &span.full, .Xchg, false, .monotonic)) {
+            if (span.full and @atomicRmw(bool, &span.full, .Xchg, false, .acq_rel)) {
                 self.deferred_partial_spans[span.class.class_idx].write(span);
             }
         }

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -43,24 +43,28 @@ fn bench(num_threads: u32) !void {
     try jdz_global_mixed(num_threads);
     try c_mixed(num_threads);
     // try gpa_mixed(num_threads);
+    try smp_mixed(num_threads);
 
     try std.io.getStdOut().writer().print("==Small Alloc==\n", .{});
     try jdz_small(num_threads);
     try jdz_global_small(num_threads);
     try c_small(num_threads);
     // try gpa_small(num_threads);
+    try smp_small(num_threads);
 
     try std.io.getStdOut().writer().print("==Medium Alloc==\n", .{});
     try jdz_medium(num_threads);
     try jdz_global_medium(num_threads);
     try c_medium(num_threads);
     // try gpa_medium(num_threads);
+    try smp_medium(num_threads);
 
     try std.io.getStdOut().writer().print("==Big Alloc==\n", .{});
     try jdz_big(num_threads);
     try jdz_global_big(num_threads);
     try c_big(num_threads);
     // try gpa_big(num_threads);
+    try smp_big(num_threads);
 
     try std.io.getStdOut().writer().print("\n", .{});
 }
@@ -93,6 +97,12 @@ fn gpa_mixed(num_threads: u32) !void {
     defer _ = gpa.deinit();
 
     try runPerfTestAlloc("gpa/mixed", mixed_min, mixed_max, allocator, mixed_rounds, num_threads);
+}
+
+fn smp_mixed(num_threads: u32) !void {
+    const allocator = std.heap.smp_allocator;
+
+    try runPerfTestAlloc("smp/mixed", mixed_min, mixed_max, allocator, mixed_rounds, num_threads);
 }
 
 fn c_mixed(num_threads: u32) !void {
@@ -137,6 +147,12 @@ fn gpa_small(num_threads: u32) !void {
     try runPerfTestAlloc("gpa/small", small_min, small_max, allocator, small_rounds, num_threads);
 }
 
+fn smp_small(num_threads: u32) !void {
+    const allocator = std.heap.smp_allocator;
+
+    try runPerfTestAlloc("smp/small", small_min, small_max, allocator, small_rounds, num_threads);
+}
+
 ///
 /// Medium
 ///
@@ -170,6 +186,12 @@ fn gpa_medium(num_threads: u32) !void {
     defer _ = gpa.deinit();
 
     try runPerfTestAlloc("gpa/medium", medium_min, medium_max, allocator, medium_rounds, num_threads);
+}
+
+fn smp_medium(num_threads: u32) !void {
+    const allocator = std.heap.smp_allocator;
+
+    try runPerfTestAlloc("smp/medium", small_min, small_max, allocator, small_rounds, num_threads);
 }
 
 ///
@@ -206,6 +228,12 @@ fn gpa_big(num_threads: u32) !void {
     defer _ = gpa.deinit();
 
     try runPerfTestAlloc("gpa/big", big_min, big_max, allocator, big_rounds, num_threads);
+}
+
+fn smp_big(num_threads: u32) !void {
+    const allocator = std.heap.smp_allocator;
+
+    try runPerfTestAlloc("smp/big", small_min, small_max, allocator, small_rounds, num_threads);
 }
 
 ///

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -215,7 +215,7 @@ fn threadAllocWorker(min: usize, max: usize, allocator: std.mem.Allocator, max_r
     var slots = std.BoundedArray([]u8, BUFFER_CAPACITY){};
     var rounds: usize = max_rounds;
 
-    var random_source = std.rand.DefaultPrng.init(1337);
+    var random_source = std.Random.DefaultPrng.init(1337);
     const rng = random_source.random();
 
     while (rounds > 0) {

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -42,25 +42,25 @@ fn bench(num_threads: u32) !void {
     try jdz_mixed(num_threads);
     try jdz_global_mixed(num_threads);
     try c_mixed(num_threads);
-    try gpa_mixed(num_threads);
+    // try gpa_mixed(num_threads);
 
     try std.io.getStdOut().writer().print("==Small Alloc==\n", .{});
     try jdz_small(num_threads);
     try jdz_global_small(num_threads);
     try c_small(num_threads);
-    try gpa_small(num_threads);
+    // try gpa_small(num_threads);
 
     try std.io.getStdOut().writer().print("==Medium Alloc==\n", .{});
     try jdz_medium(num_threads);
     try jdz_global_medium(num_threads);
     try c_medium(num_threads);
-    try gpa_medium(num_threads);
+    // try gpa_medium(num_threads);
 
     try std.io.getStdOut().writer().print("==Big Alloc==\n", .{});
     try jdz_big(num_threads);
     try jdz_global_big(num_threads);
     try c_big(num_threads);
-    try gpa_big(num_threads);
+    // try gpa_big(num_threads);
 
     try std.io.getStdOut().writer().print("\n", .{});
 }

--- a/src/bench.zig
+++ b/src/bench.zig
@@ -42,28 +42,28 @@ fn bench(num_threads: u32) !void {
     try jdz_mixed(num_threads);
     try jdz_global_mixed(num_threads);
     try c_mixed(num_threads);
-    // try gpa_mixed(num_threads);
+    try gpa_mixed(num_threads);
     try smp_mixed(num_threads);
 
     try std.io.getStdOut().writer().print("==Small Alloc==\n", .{});
     try jdz_small(num_threads);
     try jdz_global_small(num_threads);
     try c_small(num_threads);
-    // try gpa_small(num_threads);
+    try gpa_small(num_threads);
     try smp_small(num_threads);
 
     try std.io.getStdOut().writer().print("==Medium Alloc==\n", .{});
     try jdz_medium(num_threads);
     try jdz_global_medium(num_threads);
     try c_medium(num_threads);
-    // try gpa_medium(num_threads);
+    try gpa_medium(num_threads);
     try smp_medium(num_threads);
 
     try std.io.getStdOut().writer().print("==Big Alloc==\n", .{});
     try jdz_big(num_threads);
     try jdz_global_big(num_threads);
     try c_big(num_threads);
-    // try gpa_big(num_threads);
+    try gpa_big(num_threads);
     try smp_big(num_threads);
 
     try std.io.getStdOut().writer().print("\n", .{});

--- a/src/bounded_mpmc_queue.zig
+++ b/src/bounded_mpmc_queue.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const utils = @import("utils.zig");
 const testing = std.testing;
-const assert = std.debug.assert;
+const assert = utils.assert;
 const Value = std.atomic.Value;
 
 const cache_line = std.atomic.cache_line;

--- a/src/bounded_mpmc_queue.zig
+++ b/src/bounded_mpmc_queue.zig
@@ -57,7 +57,7 @@ pub fn BoundedMpmcQueue(comptime T: type, comptime buffer_size: usize) type {
                 } else if (diff < 0) {
                     return false;
                 } else {
-                    pos = self.enqueue_pos.load(.monotonic);
+                    pos = self.enqueue_pos.load(.acquire);
                 }
             }
 
@@ -83,7 +83,7 @@ pub fn BoundedMpmcQueue(comptime T: type, comptime buffer_size: usize) type {
                 } else if (diff < 0) {
                     return null;
                 } else {
-                    pos = self.dequeue_pos.load(.monotonic);
+                    pos = self.dequeue_pos.load(.acquire);
                 }
             }
 

--- a/src/bounded_mpsc_queue.zig
+++ b/src/bounded_mpsc_queue.zig
@@ -3,7 +3,7 @@ const jdz_allocator = @import("jdz_allocator.zig");
 const utils = @import("utils.zig");
 
 const testing = std.testing;
-const assert = std.debug.assert;
+const assert = utils.assert;
 const Value = std.atomic.Value;
 
 const cache_line = std.atomic.cache_line;

--- a/src/bounded_stack.zig
+++ b/src/bounded_stack.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const utils = @import("utils.zig");
 
 const testing = std.testing;
-const assert = std.debug.assert;
+const assert = utils.assert;
 
 pub fn BoundedStack(comptime T: type, comptime buffer_size: usize) type {
     return extern struct {

--- a/src/global_allocator.zig
+++ b/src/global_allocator.zig
@@ -15,7 +15,7 @@ const Value = std.atomic.Value;
 
 const log2 = std.math.log2;
 const testing = std.testing;
-const assert = std.debug.assert;
+const assert = utils.assert;
 
 pub fn JdzGlobalAllocator(comptime config: JdzAllocConfig) type {
     const Arena = span_arena.Arena(config, true);
@@ -710,3 +710,35 @@ test "consecutive overalignment" {
         allocator.free(buffer);
     }
 }
+
+// test "consecutive small allocations parallel" {
+//     const jdz_allocator = JdzGlobalAllocator(.{
+//         .thread_safe = true,
+//         .shared_arena_batch_size = 2
+//     });
+//     defer jdz_allocator.deinit();
+
+//     const allocator = jdz_allocator.allocator();
+
+//     const spawn = struct {
+//         fn thread_spawn(alloc_m: @TypeOf(jdz_allocator), alloc: std.mem.Allocator) !void {
+//             var pointers: [50]*u64 = undefined;
+//             for (&pointers) |*ptr| {
+//                 ptr.* = try alloc.create(u64);
+//             }
+//             for (&pointers) |ptr| {
+//                 alloc.destroy(ptr);
+//             }
+
+//             alloc_m.deinitThread();
+//         }
+//     };
+
+//     var threads: [8]std.Thread = undefined;
+//     for (0..8) |i| {
+//         threads[i] = try std.Thread.spawn(.{}, spawn, .{jdz_allocator, allocator});
+//     }
+//     for (threads) |t| {
+//         t.join();
+//     }
+// }

--- a/src/global_allocator.zig
+++ b/src/global_allocator.zig
@@ -711,34 +711,34 @@ test "consecutive overalignment" {
     }
 }
 
-// test "consecutive small allocations parallel" {
-//     const jdz_allocator = JdzGlobalAllocator(.{
-//         .thread_safe = true,
-//         .shared_arena_batch_size = 2
-//     });
-//     defer jdz_allocator.deinit();
+test "consecutive small allocations parallel" {
+    const jdz_allocator = JdzGlobalAllocator(.{
+        .thread_safe = true,
+        .shared_arena_batch_size = 2
+    });
+    defer jdz_allocator.deinit();
 
-//     const allocator = jdz_allocator.allocator();
+    const allocator = jdz_allocator.allocator();
 
-//     const spawn = struct {
-//         fn thread_spawn(alloc_m: @TypeOf(jdz_allocator), alloc: std.mem.Allocator) !void {
-//             var pointers: [50]*u64 = undefined;
-//             for (&pointers) |*ptr| {
-//                 ptr.* = try alloc.create(u64);
-//             }
-//             for (&pointers) |ptr| {
-//                 alloc.destroy(ptr);
-//             }
+    const spawn = struct {
+        fn thread_spawn(alloc_m: @TypeOf(jdz_allocator), alloc: std.mem.Allocator) !void {
+            var pointers: [50]*u64 = undefined;
+            for (&pointers) |*ptr| {
+                ptr.* = try alloc.create(u64);
+            }
+            for (&pointers) |ptr| {
+                alloc.destroy(ptr);
+            }
 
-//             alloc_m.deinitThread();
-//         }
-//     }.thread_spawn;
+            alloc_m.deinitThread();
+        }
+    }.thread_spawn;
 
-//     var threads: [8]std.Thread = undefined;
-//     for (0..8) |i| {
-//         threads[i] = try std.Thread.spawn(.{}, spawn, .{jdz_allocator, allocator});
-//     }
-//     for (threads) |t| {
-//         t.join();
-//     }
-// }
+    var threads: [8]std.Thread = undefined;
+    for (0..8) |i| {
+        threads[i] = try std.Thread.spawn(.{}, spawn, .{jdz_allocator, allocator});
+    }
+    for (threads) |t| {
+        t.join();
+    }
+}

--- a/src/global_allocator.zig
+++ b/src/global_allocator.zig
@@ -732,7 +732,7 @@ test "consecutive overalignment" {
 
 //             alloc_m.deinitThread();
 //         }
-//     };
+//     }.thread_spawn;
 
 //     var threads: [8]std.Thread = undefined;
 //     for (0..8) |i| {

--- a/src/global_allocator.zig
+++ b/src/global_allocator.zig
@@ -711,34 +711,34 @@ test "consecutive overalignment" {
     }
 }
 
-test "consecutive small allocations parallel" {
-    const jdz_allocator = JdzGlobalAllocator(.{
-        .thread_safe = true,
-        .shared_arena_batch_size = 2
-    });
-    defer jdz_allocator.deinit();
+// test "consecutive small allocations parallel" {
+//     const jdz_allocator = JdzGlobalAllocator(.{
+//         .thread_safe = true,
+//         .shared_arena_batch_size = 2
+//     });
+//     defer jdz_allocator.deinit();
 
-    const allocator = jdz_allocator.allocator();
+//     const allocator = jdz_allocator.allocator();
 
-    const spawn = struct {
-        fn thread_spawn(alloc_m: @TypeOf(jdz_allocator), alloc: std.mem.Allocator) !void {
-            var pointers: [50]*u64 = undefined;
-            for (&pointers) |*ptr| {
-                ptr.* = try alloc.create(u64);
-            }
-            for (&pointers) |ptr| {
-                alloc.destroy(ptr);
-            }
+//     const spawn = struct {
+//         fn thread_spawn(alloc_m: @TypeOf(jdz_allocator), alloc: std.mem.Allocator) !void {
+//             var pointers: [50]*u64 = undefined;
+//             for (&pointers) |*ptr| {
+//                 ptr.* = try alloc.create(u64);
+//             }
+//             for (&pointers) |ptr| {
+//                 alloc.destroy(ptr);
+//             }
 
-            alloc_m.deinitThread();
-        }
-    }.thread_spawn;
+//             alloc_m.deinitThread();
+//         }
+//     }.thread_spawn;
 
-    var threads: [8]std.Thread = undefined;
-    for (0..8) |i| {
-        threads[i] = try std.Thread.spawn(.{}, spawn, .{jdz_allocator, allocator});
-    }
-    for (threads) |t| {
-        t.join();
-    }
-}
+//     var threads: [8]std.Thread = undefined;
+//     for (0..8) |i| {
+//         threads[i] = try std.Thread.spawn(.{}, spawn, .{jdz_allocator, allocator});
+//     }
+//     for (threads) |t| {
+//         t.join();
+//     }
+// }

--- a/src/grow_shrink_bench.zig
+++ b/src/grow_shrink_bench.zig
@@ -215,7 +215,7 @@ fn gpa_big(num_threads: u32) !void {
 fn threadAllocWorker(min: usize, max: usize, allocator: std.mem.Allocator, max_rounds: usize) !void {
     var rounds: usize = max_rounds;
 
-    var random_source = std.rand.DefaultPrng.init(1337);
+    var random_source = std.Random.DefaultPrng.init(1337);
     const rng = random_source.random();
 
     while (rounds > 0) {

--- a/src/jdz_allocator.zig
+++ b/src/jdz_allocator.zig
@@ -48,7 +48,7 @@ pub const JdzAllocConfig = struct {
 
     /// JdzSharedAllocator batch arena instantiation amount
     /// prevents allocator-induced false sharing if greater than total number of allocating threads
-    shared_arena_batch_size: u32 = if (builtin.is_test) 2 else 8,
+    shared_arena_batch_size: u32 = 8,
 
     /// if leaks should be reported - only works with JdzSharedAllocator
     report_leaks: bool = builtin.mode == .Debug,

--- a/src/jdz_allocator.zig
+++ b/src/jdz_allocator.zig
@@ -48,7 +48,7 @@ pub const JdzAllocConfig = struct {
 
     /// JdzSharedAllocator batch arena instantiation amount
     /// prevents allocator-induced false sharing if greater than total number of allocating threads
-    shared_arena_batch_size: u32 = 8,
+    shared_arena_batch_size: u32 = if (builtin.is_test) 2 else 8,
 
     /// if leaks should be reported - only works with JdzSharedAllocator
     report_leaks: bool = builtin.mode == .Debug,

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -699,6 +699,7 @@ test "consecutive overalignment" {
 }
 
 test "small allocations parallel" {
+    const test_iterations = 50;
     var jdz_allocator = JdzAllocator(.{
         .thread_safe = true,
         .shared_arena_batch_size = 2
@@ -714,22 +715,24 @@ test "small allocations parallel" {
         }
     }.thread_spawn;
 
-    var threads: [5]std.Thread = undefined;
-    for (0..5) |i| {
-        threads[i] = try std.Thread.spawn(.{}, spawn, .{allocator});
-    }
-    for (threads) |t| {
-        t.join();
+    for (0..test_iterations) |_| {
+        var threads: [5]std.Thread = undefined;
+        for (0..5) |i| {
+            threads[i] = try std.Thread.spawn(.{}, spawn, .{allocator});
+        }
+        for (threads) |t| {
+            t.join();
+        }
     }
 }
 
 test "consecutive small allocations parallel" {
+    const test_iterations = 50;
     var jdz_allocator = JdzAllocator(.{
         .thread_safe = true,
         .shared_arena_batch_size = 2
     }).init();
     defer jdz_allocator.deinit();
-
     const allocator = jdz_allocator.allocator();
 
     const spawn = struct {
@@ -744,16 +747,19 @@ test "consecutive small allocations parallel" {
         }
     }.thread_spawn;
 
-    var threads: [8]std.Thread = undefined;
-    for (0..8) |i| {
-        threads[i] = try std.Thread.spawn(.{}, spawn, .{allocator});
-    }
-    for (threads) |t| {
-        t.join();
+    for (0..test_iterations) |_| {
+        var threads: [8]std.Thread = undefined;
+        for (0..8) |i| {
+            threads[i] = try std.Thread.spawn(.{}, spawn, .{allocator});
+        }
+        for (threads) |t| {
+            t.join();
+        }
     }
 }
 
 test "consecutive small allocations parallel with multi-allocators" {
+    const test_iterations = 50;
     var jdz_allocator = JdzAllocator(.{
         .thread_safe = true,
         .shared_arena_batch_size = 2
@@ -784,28 +790,28 @@ test "consecutive small allocations parallel with multi-allocators" {
         }
     }.thread_spawn;
 
-    var threads: [8]std.Thread = undefined;
-    for (0..8) |i| {
-        threads[i] = try std.Thread.spawn(.{}, spawn, .{allocator, allocator2});
-    }
-    for (threads) |t| {
-        t.join();
+    for (0..test_iterations) |_| {
+        var threads: [8]std.Thread = undefined;
+        for (0..8) |i| {
+            threads[i] = try std.Thread.spawn(.{}, spawn, .{allocator, allocator2});
+        }
+        for (threads) |t| {
+            t.join();
+        }
     }
 }
 
 test "synchronized memory allocation and deallocation" {
+    const test_iterations = 50;
     var jdz_allocator = JdzAllocator(.{
         .thread_safe = true,
         .shared_arena_batch_size = 2
     }).init();
     defer jdz_allocator.deinit();
-
     const allocator = jdz_allocator.allocator();
 
     var mutex = std.Thread.Mutex{};
     var condition = std.Thread.Condition{};
-    var shared_list = std.ArrayList(*u64).init(std.testing.allocator);
-    defer shared_list.deinit();
 
     const allocator_thread = struct {
         fn run(
@@ -847,12 +853,17 @@ test "synchronized memory allocation and deallocation" {
         }
     }.run;
 
-    const allocator_t = try std.Thread.spawn(.{}, allocator_thread, .{allocator, &shared_list, &mutex, &condition});
-    const deallocator_t = try std.Thread.spawn(.{}, deallocator_thread, .{allocator, &shared_list, &mutex, &condition});
+    for (0..test_iterations) |_| {
+        var shared_list = std.ArrayList(*u64).init(std.testing.allocator);
+        defer shared_list.deinit();
 
-    allocator_t.join();
-    deallocator_t.join();
+        const allocator_t = try std.Thread.spawn(.{}, allocator_thread, .{allocator, &shared_list, &mutex, &condition});
+        const deallocator_t = try std.Thread.spawn(.{}, deallocator_thread, .{allocator, &shared_list, &mutex, &condition});
 
-    try std.testing.expectEqual(@as(usize, 0), shared_list.items.len);
+        allocator_t.join();
+        deallocator_t.join();
+
+        try std.testing.expectEqual(@as(usize, 0), shared_list.items.len);
+    }
 }
 

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -75,21 +75,23 @@ pub fn JdzAllocator(comptime config: JdzAllocConfig) type {
                 .vtable = &.{
                     .alloc = alloc,
                     .resize = resize,
+                    .remap = remap,
                     .free = free,
                 },
             };
         }
 
-        fn alloc(ctx: *anyopaque, len: usize, log2_align: u8, ret_addr: usize) ?[*]u8 {
+        fn alloc(ctx: *anyopaque, len: usize, log2_align: std.mem.Alignment, ret_addr: usize) ?[*]u8 {
             _ = ret_addr;
 
             const self: *Self = @ptrCast(@alignCast(ctx));
 
-            if (log2_align <= small_granularity_shift) {
+            const log2_align_value = @intFromEnum(log2_align);
+            if (log2_align_value <= small_granularity_shift) {
                 return @call(.always_inline, allocate, .{ self, len });
             }
 
-            const alignment = @as(usize, 1) << @intCast(log2_align);
+            const alignment = @as(usize, 1) << @intCast(log2_align_value);
             const size = @max(alignment, len);
 
             if (size <= span_header_size) {
@@ -119,10 +121,10 @@ pub fn JdzAllocator(comptime config: JdzAllocConfig) type {
             return null;
         }
 
-        fn resize(ctx: *anyopaque, buf: []u8, log2_align: u8, new_len: usize, ret_addr: usize) bool {
+        fn resize(ctx: *anyopaque, buf: []u8, log2_align: std.mem.Alignment, new_len: usize, ret_addr: usize) bool {
             _ = ret_addr;
             _ = ctx;
-            const alignment = @as(usize, 1) << @intCast(log2_align);
+            const alignment = @as(usize, 1) << @intCast(@intFromEnum(log2_align));
             const aligned = (@intFromPtr(buf.ptr) & (alignment - 1)) == 0;
 
             const span = @call(.always_inline, utils.getSpan, .{buf.ptr});
@@ -136,7 +138,15 @@ pub fn JdzAllocator(comptime config: JdzAllocConfig) type {
             return aligned and new_len <= max_len;
         }
 
-        fn free(ctx: *anyopaque, buf: []u8, log2_align: u8, ret_addr: usize) void {
+        fn remap(ctx: *anyopaque, buf: []u8, alignment: std.mem.Alignment, new_len: usize, return_address: usize) ?[*]u8 {
+            if (resize(ctx, buf, alignment, new_len, return_address)) {
+                return buf.ptr;
+            }
+            return null;
+        }
+
+
+        fn free(ctx: *anyopaque, buf: []u8, log2_align: std.mem.Alignment, ret_addr: usize) void {
             _ = ctx;
             _ = ret_addr;
             _ = log2_align;
@@ -257,7 +267,7 @@ test "small allocations - free in reverse order" {
         try list.append(ptr);
     }
 
-    while (list.popOrNull()) |ptr| {
+    while (list.pop()) |ptr| {
         allocator.destroy(ptr);
     }
 }
@@ -435,7 +445,7 @@ test "shrink large object to large object with larger alignment" {
         try stuff_to_free.append(slice);
         slice = try allocator.alignedAlloc(u8, 16, alloc_size);
     }
-    while (stuff_to_free.popOrNull()) |item| {
+    while (stuff_to_free.pop()) |item| {
         allocator.free(item);
     }
     slice[0] = 0x12;
@@ -485,7 +495,7 @@ test "realloc large object to larger alignment" {
         try stuff_to_free.append(slice);
         slice = try allocator.alignedAlloc(u8, 16, 8192 + 50);
     }
-    while (stuff_to_free.popOrNull()) |item| {
+    while (stuff_to_free.pop()) |item| {
         allocator.free(item);
     }
     slice[0] = 0x12;
@@ -568,8 +578,8 @@ test "small alignment small alloc" {
 
     const allocator = jdz_allocator.allocator();
 
-    const slice = allocator.rawAlloc(1, 4, @returnAddress()).?;
-    defer allocator.rawFree(slice[0..1], 4, @returnAddress());
+    const slice = allocator.rawAlloc(1, .@"4", @returnAddress()).?;
+    defer allocator.rawFree(slice[0..1], .@"4", @returnAddress());
 
     try std.testing.expect(@intFromPtr(slice) % std.math.pow(u16, 2, 4) == 0);
 }
@@ -584,8 +594,8 @@ test "medium alignment small alloc" {
 
     if (alignment > page_alignment) return error.SkipZigTest;
 
-    const slice = allocator.rawAlloc(1, alignment, @returnAddress()).?;
-    defer allocator.rawFree(slice[0..1], alignment, @returnAddress());
+    const slice = allocator.rawAlloc(1, @enumFromInt(alignment), @returnAddress()).?;
+    defer allocator.rawFree(slice[0..1], @enumFromInt(alignment), @returnAddress());
 
     try std.testing.expect(@intFromPtr(slice) % std.math.pow(u16, 2, 4) == 0);
 }
@@ -596,8 +606,8 @@ test "page size alignment small alloc" {
 
     const allocator = jdz_allocator.allocator();
 
-    const slice = allocator.rawAlloc(1, page_alignment, @returnAddress()).?;
-    defer allocator.rawFree(slice[0..1], page_alignment, @returnAddress());
+    const slice = allocator.rawAlloc(1, @enumFromInt(page_alignment), @returnAddress()).?;
+    defer allocator.rawFree(slice[0..1], @enumFromInt(page_alignment), @returnAddress());
 
     try std.testing.expect(@intFromPtr(slice) % std.math.pow(u16, 2, page_alignment) == 0);
 }
@@ -608,8 +618,8 @@ test "small alignment large alloc" {
 
     const allocator = jdz_allocator.allocator();
 
-    const slice = allocator.rawAlloc(span_max, 4, @returnAddress()).?;
-    defer allocator.rawFree(slice[0..span_max], 4, @returnAddress());
+    const slice = allocator.rawAlloc(span_max, .@"4", @returnAddress()).?;
+    defer allocator.rawFree(slice[0..span_max], .@"4", @returnAddress());
 
     try std.testing.expect(@intFromPtr(slice) % std.math.pow(u16, 2, 4) == 0);
 }
@@ -624,8 +634,8 @@ test "medium alignment large alloc" {
 
     if (alignment > page_alignment) return error.SkipZigTest;
 
-    const slice = allocator.rawAlloc(span_max, alignment, @returnAddress()).?;
-    defer allocator.rawFree(slice[0..span_max], alignment, @returnAddress());
+    const slice = allocator.rawAlloc(span_max, @enumFromInt(alignment), @returnAddress()).?;
+    defer allocator.rawFree(slice[0..span_max], @enumFromInt(alignment), @returnAddress());
 
     try std.testing.expect(@intFromPtr(slice) % std.math.pow(u16, 2, 4) == 0);
 }
@@ -636,8 +646,8 @@ test "page size alignment large alloc" {
 
     const allocator = jdz_allocator.allocator();
 
-    const slice = allocator.rawAlloc(span_max, page_alignment, @returnAddress()).?;
-    defer allocator.rawFree(slice[0..span_max], page_alignment, @returnAddress());
+    const slice = allocator.rawAlloc(span_max, @enumFromInt(page_alignment), @returnAddress()).?;
+    defer allocator.rawFree(slice[0..span_max], @enumFromInt(page_alignment), @returnAddress());
 
     try std.testing.expect(@intFromPtr(slice) % std.math.pow(u16, 2, page_alignment) == 0);
 }

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -725,7 +725,7 @@ test "consecutive small allocations parallel" {
     }
 }
 
-test "consecutive small allocations parallel with multi-allocators" {
+fn multi_allocator_test() !void {
     var jdz_allocator = JdzAllocator(.{
         .thread_safe = true,
         .shared_arena_batch_size = 2
@@ -762,5 +762,15 @@ test "consecutive small allocations parallel with multi-allocators" {
     }
     for (threads) |t| {
         t.join();
+    }
+}
+
+test "consecutive small allocations parallel with multi-allocators" {
+    try multi_allocator_test();
+}
+
+test "consecutive small allocations parallel with multi-allocators - 500 iterations" {
+    for (0..500) |_| {
+        try multi_allocator_test();
     }
 }

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -753,7 +753,7 @@ test "consecutive small allocations parallel" {
     }
 }
 
-fn multi_allocator_test() !void {
+test "consecutive small allocations parallel with multi-allocators" {
     var jdz_allocator = JdzAllocator(.{
         .thread_safe = true,
         .shared_arena_batch_size = 2
@@ -762,7 +762,7 @@ fn multi_allocator_test() !void {
 
     var jdz_allocator2 = JdzAllocator(.{
         .thread_safe = true,
-        .shared_arena_batch_size = 2
+        .shared_arena_batch_size = 10
     }).init();
     defer jdz_allocator2.deinit();
 
@@ -793,12 +793,3 @@ fn multi_allocator_test() !void {
     }
 }
 
-test "consecutive small allocations parallel with multi-allocators" {
-    try multi_allocator_test();
-}
-
-test "consecutive small allocations parallel with multi-allocators - 500 iterations" {
-    for (0..500) |_| {
-        try multi_allocator_test();
-    }
-}

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -762,7 +762,7 @@ test "consecutive small allocations parallel with multi-allocators" {
 
     var jdz_allocator2 = JdzAllocator(.{
         .thread_safe = true,
-        .shared_arena_batch_size = 10
+        .shared_arena_batch_size = 16
     }).init();
     defer jdz_allocator2.deinit();
 

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -166,7 +166,7 @@ pub fn JdzAllocator(comptime config: JdzAllocConfig) type {
 
         fn allocate(self: *Self, size: usize) ?[*]u8 {
             const arena = @call(.always_inline, SharedArenaHandler.getArena, .{&self.arena_handler}) orelse return null;
-            defer @call(.always_inline, Arena.release, .{arena});
+            // defer @call(.always_inline, Arena.release, .{arena});
 
             if (size <= small_max) {
                 const size_class = @call(.always_inline, utils.getSmallSizeClass, .{size});
@@ -671,7 +671,10 @@ test "consecutive overalignment" {
 }
 
 test "small allocations parallel" {
-    var jdz_allocator = JdzAllocator(.{ .thread_safe = true }).init();
+    var jdz_allocator = JdzAllocator(.{
+        .thread_safe = true,
+        .shared_arena_batch_size = 2
+    }).init();
     defer jdz_allocator.deinit();
 
     const allocator = jdz_allocator.allocator();

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -14,7 +14,7 @@ const Value = std.atomic.Value;
 
 const log2 = std.math.log2;
 const testing = std.testing;
-const assert = std.debug.assert;
+const assert = utils.assert;
 
 pub fn JdzAllocator(comptime config: JdzAllocConfig) type {
     const Arena = span_arena.Arena(config, false);

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -865,3 +865,29 @@ test "synchronized memory allocation and deallocation" {
     }
 }
 
+test "comptime init" {
+    // Initialize the allocator with comptime init
+    var jdz_allocator = comptime JdzAllocator(.{}).init();
+    defer jdz_allocator.deinit();
+    
+    const allocator = jdz_allocator.allocator();
+    
+    // Test basic allocation and deallocation
+    const small_ptr = try allocator.create(u32);
+    small_ptr.* = 42;
+    try std.testing.expectEqual(@as(u32, 42), small_ptr.*);
+    allocator.destroy(small_ptr);
+    
+    // Test array allocation
+    const array_ptr = try allocator.alloc(u8, 100);
+    @memset(array_ptr, 0xAA);
+    try std.testing.expectEqual(@as(u8, 0xAA), array_ptr[50]);
+    allocator.free(array_ptr);
+    
+    // Test larger allocation
+    const large_ptr = try allocator.alloc(u8, 8000);
+    @memset(large_ptr, 0xBB);
+    try std.testing.expectEqual(@as(u8, 0xBB), large_ptr[4000]);
+    allocator.free(large_ptr);
+}
+

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -874,20 +874,23 @@ test "comptime init" {
     
     // Test basic allocation and deallocation
     const small_ptr = try allocator.create(u32);
+    defer allocator.destroy(small_ptr);
+
     small_ptr.* = 42;
     try std.testing.expectEqual(@as(u32, 42), small_ptr.*);
-    allocator.destroy(small_ptr);
     
     // Test array allocation
     const array_ptr = try allocator.alloc(u8, 100);
+    defer allocator.free(array_ptr);
+
     @memset(array_ptr, 0xAA);
     try std.testing.expectEqual(@as(u8, 0xAA), array_ptr[50]);
-    allocator.free(array_ptr);
     
     // Test larger allocation
     const large_ptr = try allocator.alloc(u8, 8000);
+    defer allocator.free(large_ptr);
+
     @memset(large_ptr, 0xBB);
     try std.testing.expectEqual(@as(u8, 0xBB), large_ptr[4000]);
-    allocator.free(large_ptr);
 }
 

--- a/src/shared_allocator.zig
+++ b/src/shared_allocator.zig
@@ -10,10 +10,8 @@ const span_file = @import("span.zig");
 
 const Span = span_file.Span;
 const JdzAllocConfig = jdz.JdzAllocConfig;
-const Value = std.atomic.Value;
 
 const log2 = std.math.log2;
-const testing = std.testing;
 const assert = utils.assert;
 
 pub fn JdzAllocator(comptime config: JdzAllocConfig) type {

--- a/src/shared_arena_handler.zig
+++ b/src/shared_arena_handler.zig
@@ -15,24 +15,23 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
     const Mutex = utils.getMutexType(config);
 
     return struct {
-        first_arena: ?*Arena,
-        last_arena: ?*Arena,
+        const ArenasSet = struct {
+            arenas: [config.shared_arena_batch_size]Arena,
+            next: ?*ArenasSet
+        };
 
-        first_free_arena: ?*Arena,
-        last_free_arena: ?*Arena,
+        first_arenas_set: ?*ArenasSet,
+        last_arenas_set: ?*ArenasSet,
 
         mutex: Mutex,
-        arenas: usize = 0,
-        free_arenas: usize = 0,
+        arenas_batch: usize = 0,
 
         const Self = @This();
 
         pub fn init() Self {
             return .{
-                .first_arena = null,
-                .last_arena = null,
-                .first_free_arena = null,
-                .last_free_arena = null,
+                .first_arenas_set = null,
+                .last_arenas_set = null,
                 .mutex = .{},
             };
         }
@@ -42,25 +41,28 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
             defer self.mutex.unlock();
 
             var spans_leaked: usize = 0;
-            var opt_arena = self.first_arena;
+            var opt_arenas_set = self.first_arenas_set;
 
-            while (opt_arena) |arena| {
-                const next = arena.next;
+            while (opt_arenas_set) |arenas_set| {
+                const next = arenas_set.next;
 
-                spans_leaked += arena.deinit();
-
-                opt_arena = next;
-            }
-
-            while (opt_arena) |arena| {
-                const next = arena.next;
-
-                if (arena.is_alloc_master) {
-                    config.backing_allocator.destroy(arena);
+                for (&arenas_set.arenas) |*arena| {
+                    spans_leaked += arena.deinit();
                 }
 
-                opt_arena = next;
+                opt_arenas_set = next;
             }
+
+            // Unreachable code?
+            // while (opt_arenas_set) |arenas_set| {
+            //     const next = arenas_set.next;
+
+            //     if (arena.is_alloc_master) {
+            //         config.backing_allocator.destroy(arenas_set);
+            //     }
+
+            //     opt_arenas_set = next;
+            // }
 
             return spans_leaked;
         }
@@ -70,148 +72,108 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
 
             const mutex = &self.mutex;
 
-            var first_arena: ?*Arena = undefined;
-            var first_free_arena: ?*Arena = undefined;
+            var first_arenas_set: ?*ArenasSet = undefined;
             var arenas: usize = undefined;
-            var free_arenas: usize = undefined;
 
             {
                 mutex.lock();
                 defer mutex.unlock();
 
-                first_arena = self.first_arena;
-                first_free_arena = self.first_free_arena;
-                arenas = self.arenas;
-                free_arenas = self.free_arenas;
+                first_arenas_set = self.first_arenas_set;
+                arenas = self.arenas_batch;
             }
 
-            if (first_arena) |f_arena| {
-                return findOwnedThreadArena(tid, f_arena, arenas) orelse
-                    self.claimOrCreateArena(
-                        tid, arenas, free_arenas, f_arena, first_free_arena
-                    );
+            if (first_arenas_set) |f_arenas| {
+                return findOwnedThreadArena(tid, f_arenas, arenas) orelse
+                    self.claimOrCreateArena(tid, arenas, f_arenas);
             }else{
-                return self.createArena(arenas);
+                return self.createArena(tid, arenas);
             }
         }
 
-        inline fn findOwnedThreadArena(tid: std.Thread.Id, first_arena: *Arena, arenas: usize) ?*Arena {
-            var opt_arena = first_arena;
-            for (1..arenas) |_| {
-                if (opt_arena.thread_id == tid) {
-                    return acquireArena(opt_arena, tid) orelse continue;
+        inline fn findOwnedThreadArena(tid: std.Thread.Id, first_arenas: *ArenasSet, arenas_batch: usize) ?*Arena {
+            var opt_arenas_set: *ArenasSet = first_arenas;
+            for (1..arenas_batch) |_| {
+                for (&opt_arenas_set.arenas) |*arena| {
+                    if (arena.thread_id == tid) {
+                        return acquireArena(arena, tid) orelse continue;
+                    }
                 }
 
-                opt_arena = opt_arena.next.?;
+                opt_arenas_set = opt_arenas_set.next.?;
             }
 
-            if (opt_arena.thread_id == tid) {
-                return acquireArena(opt_arena, tid);
+            for (&opt_arenas_set.arenas) |*arena| {
+                if (arena.thread_id == tid) {
+                    return acquireArena(arena, tid) orelse continue;
+                }
             }
 
             return null;
         }
 
-        inline fn claimArena(tid: std.Thread.Id, arenas: usize, first_arena: *Arena) ?*Arena {
-            var opt_arena = first_arena;
-            for (1..arenas) |_| {
-                return acquireArena(opt_arena, tid) orelse {
-                    opt_arena = opt_arena.next.?;
+        inline fn claimOrCreateArena(
+            self: *Self, tid: std.Thread.Id, arenas_batch: usize, first_arenas: *ArenasSet
+        ) ?*Arena {
+            var opt_arenas_set: *ArenasSet = first_arenas;
+            for (1..arenas_batch) |_| {
+                for (&opt_arenas_set.arenas) |*arena| {
+                    return acquireArena(arena, tid) orelse {
+                        opt_arenas_set = opt_arenas_set.next.?;
+                        continue;
+                    };
+                }
+
+                opt_arenas_set = opt_arenas_set.next.?;
+            }
+
+            for (&opt_arenas_set.arenas) |*arena| {
+                return acquireArena(arena, tid) orelse {
+                    opt_arenas_set = opt_arenas_set.next.?;
                     continue;
                 };
             }
 
-            return acquireArena(opt_arena, tid);
+            return self.createArena(tid, arenas_batch);
         }
 
-        inline fn claimOrCreateArena(
-            self: *Self, tid: std.Thread.Id, arenas: usize, free_arenas: usize,
-            first_arena: *Arena, first_free_arena: ?*Arena
-        ) ?*Arena {
-            if (first_free_arena) |ff_arena| {
-                if (claimArena(tid, free_arenas, ff_arena)) |arena| {
-                    const mutex = &self.mutex;
-                    mutex.lock();
-                    defer mutex.unlock();
-
-                    self.free_arenas -= 1;
-                    self.last_arena = arena;
-                    if (arena.next) |ptr| {
-                        self.first_free_arena = ptr;
-                    }else{
-                        self.first_free_arena = null;
-                        self.last_free_arena = null;
-                    }
-
-                    return arena;
-                }
-            }
-
-            return claimArena(tid, arenas, first_arena) orelse self.createArena(arenas);
-        }
-
-        fn createArena(self: *Self, prev_arena_batch: usize) ?*Arena {
+        fn createArena(self: *Self, tid: std.Thread.Id, prev_arena_batch: usize) ?*Arena {
             const mutex = &self.mutex;
             mutex.lock();
 
-            if (self.arenas != prev_arena_batch) {
+            if (self.arenas_batch != prev_arena_batch) {
                 mutex.unlock();
                 return self.getArena();
             }
 
             defer mutex.unlock();
 
-            const new_arenas = config.backing_allocator.alloc(Arena, config.shared_arena_batch_size) catch {
+            const new_arenas_set = config.backing_allocator.create(ArenasSet) catch {
                 return null;
             };
 
-            self.arenas += config.shared_arena_batch_size;
 
-            const first_arena = &new_arenas[0];
-            var prev_arena = first_arena;
-            prev_arena.* = Arena.init(.unlocked, null);
+            self.arenas_batch += 1;
 
-            for (new_arenas[1..]) |*new_arena| {
+            for (&new_arenas_set.arenas) |*new_arena| {
                 new_arena.* = Arena.init(.unlocked, null);
-                prev_arena.next = new_arena;
-                prev_arena = new_arena;
+                new_arena.thread_id = tid;
             }
+            new_arenas_set.next = null;
 
-            new_arenas[0].makeMaster();
-            const acquired = acquireArena(&new_arenas[0], getThreadId()).?;
+            const first_arena = &new_arenas_set.arenas[0];
+            first_arena.makeMaster();
+            const acquired = acquireArena(first_arena, getThreadId()).?;
 
-            if (self.last_arena) |*l_arena| {
-                l_arena.*.next = first_arena;
-                l_arena.* = first_arena;
+            if (self.last_arenas_set) |*l_arena| {
+                l_arena.*.next = new_arenas_set;
+                l_arena.* = new_arenas_set;
             }else{
-                self.first_arena = first_arena;
-                self.last_arena = first_arena;
-            }
-
-            if (config.shared_arena_batch_size > 1) {
-                self.free_arenas += config.shared_arena_batch_size - 1;
-                if (self.last_free_arena) |*lf_arena| {
-                    lf_arena.*.next = &new_arenas[1];
-                    lf_arena.* = prev_arena;
-                }else{
-                    self.first_free_arena = &new_arenas[1];
-                    self.last_free_arena = prev_arena;
-                }
+                self.first_arenas_set = new_arenas_set;
+                self.last_arenas_set = new_arenas_set;
             }
 
             return acquired;
-        }
-
-        fn addArenaToList(self: *Self, new_arena: *Arena) void {
-            if (self.first_arena == null) {
-                self.first_arena = new_arena;
-
-                return;
-            }
-
-            const arena = self.last_arena.?;
-            arena.next = new_arena;
-            self.last_arena = new_arena;
         }
 
         inline fn acquireArena(arena: *Arena, tid: std.Thread.Id) ?*Arena {

--- a/src/shared_arena_handler.zig
+++ b/src/shared_arena_handler.zig
@@ -20,9 +20,7 @@ const dispatcher_max_index = std.math.maxInt(u32)/2;
 
 pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
     // Verify batch size is power of two for optimization
-    comptime {
-        assert(utils.isPowerOfTwo(config.shared_arena_batch_size));
-    }
+    assert(utils.isPowerOfTwo(config.shared_arena_batch_size));
     const batch_size_mask = config.shared_arena_batch_size - 1;
     const Arena = span_arena.Arena(config, false);
 

--- a/src/shared_arena_handler.zig
+++ b/src/shared_arena_handler.zig
@@ -58,6 +58,10 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
         }
 
         pub inline fn getArena(self: *Self) ?*Arena {
+            const mutex = &self.mutex;
+            mutex.lock();
+            defer mutex.unlock();
+
             const tid = getThreadId();
 
             return self.findOwnedThreadArena(tid) orelse
@@ -87,19 +91,6 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
 
                     continue;
                 };
-            }
-
-            return self.tryCreateArena();
-        }
-
-        fn tryCreateArena(self: *Self) ?*Arena {
-            const arena_batch = self.arena_batch;
-
-            self.mutex.lock();
-            defer self.mutex.unlock();
-
-            if (arena_batch != self.arena_batch) {
-                return self.getArena();
             }
 
             return self.createArena();

--- a/src/shared_arena_handler.zig
+++ b/src/shared_arena_handler.zig
@@ -15,17 +15,25 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
     const Mutex = utils.getMutexType(config);
 
     return struct {
-        arena_list: ?*Arena,
+        first_arena: ?*Arena,
+        last_arena: ?*Arena,
+
+        first_free_arena: ?*Arena,
+        last_free_arena: ?*Arena,
+
         mutex: Mutex,
-        arena_batch: u32,
+        arenas: usize = 0,
+        free_arenas: usize = 0,
 
         const Self = @This();
 
         pub fn init() Self {
             return .{
-                .arena_list = null,
+                .first_arena = null,
+                .last_arena = null,
+                .first_free_arena = null,
+                .last_free_arena = null,
                 .mutex = .{},
-                .arena_batch = 0,
             };
         }
 
@@ -34,7 +42,7 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
             defer self.mutex.unlock();
 
             var spans_leaked: usize = 0;
-            var opt_arena = self.arena_list;
+            var opt_arena = self.first_arena;
 
             while (opt_arena) |arena| {
                 const next = arena.next;
@@ -57,82 +65,153 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
             return spans_leaked;
         }
 
-        pub inline fn getArena(self: *Self) ?*Arena {
-            const mutex = &self.mutex;
-            mutex.lock();
-            defer mutex.unlock();
-
+        pub fn getArena(self: *Self) ?*Arena {
             const tid = getThreadId();
 
-            return self.findOwnedThreadArena(tid) orelse
-                self.claimOrCreateArena(tid);
+            const mutex = &self.mutex;
+
+            var first_arena: ?*Arena = undefined;
+            var first_free_arena: ?*Arena = undefined;
+            var arenas: usize = undefined;
+            var free_arenas: usize = undefined;
+
+            {
+                mutex.lock();
+                defer mutex.unlock();
+
+                first_arena = self.first_arena;
+                first_free_arena = self.first_free_arena;
+                arenas = self.arenas;
+                free_arenas = self.free_arenas;
+            }
+
+            if (first_arena) |f_arena| {
+                return findOwnedThreadArena(tid, f_arena, arenas) orelse
+                    self.claimOrCreateArena(
+                        tid, arenas, free_arenas, f_arena, first_free_arena
+                    );
+            }else{
+                return self.createArena(arenas);
+            }
         }
 
-        inline fn findOwnedThreadArena(self: *Self, tid: std.Thread.Id) ?*Arena {
-            var opt_arena = self.arena_list;
-
-            while (opt_arena) |list_arena| {
-                if (list_arena.thread_id == tid or list_arena.thread_id == null) {
-                    return acquireArena(list_arena, tid) orelse continue;
+        inline fn findOwnedThreadArena(tid: std.Thread.Id, first_arena: *Arena, arenas: usize) ?*Arena {
+            var opt_arena = first_arena;
+            for (1..arenas) |_| {
+                if (opt_arena.thread_id == tid) {
+                    return acquireArena(opt_arena, tid) orelse continue;
                 }
 
-                opt_arena = list_arena.next;
+                opt_arena = opt_arena.next.?;
+            }
+
+            if (opt_arena.thread_id == tid) {
+                return acquireArena(opt_arena, tid);
             }
 
             return null;
         }
 
-        inline fn claimOrCreateArena(self: *Self, tid: std.Thread.Id) ?*Arena {
-            var opt_arena = self.arena_list;
-
-            while (opt_arena) |arena| {
-                return acquireArena(arena, tid) orelse {
-                    opt_arena = arena.next;
-
+        inline fn claimArena(tid: std.Thread.Id, arenas: usize, first_arena: *Arena) ?*Arena {
+            var opt_arena = first_arena;
+            for (1..arenas) |_| {
+                return acquireArena(opt_arena, tid) orelse {
+                    opt_arena = opt_arena.next.?;
                     continue;
                 };
             }
 
-            return self.createArena();
+            return acquireArena(opt_arena, tid);
         }
 
-        fn createArena(self: *Self) ?*Arena {
-            var new_arenas = config.backing_allocator.alloc(Arena, config.shared_arena_batch_size) catch {
+        inline fn claimOrCreateArena(
+            self: *Self, tid: std.Thread.Id, arenas: usize, free_arenas: usize,
+            first_arena: *Arena, first_free_arena: ?*Arena
+        ) ?*Arena {
+            if (first_free_arena) |ff_arena| {
+                if (claimArena(tid, free_arenas, ff_arena)) |arena| {
+                    const mutex = &self.mutex;
+                    mutex.lock();
+                    defer mutex.unlock();
+
+                    self.free_arenas -= 1;
+                    self.last_arena = arena;
+                    if (arena.next) |ptr| {
+                        self.first_free_arena = ptr;
+                    }else{
+                        self.first_free_arena = null;
+                        self.last_free_arena = null;
+                    }
+
+                    return arena;
+                }
+            }
+
+            return claimArena(tid, arenas, first_arena) orelse self.createArena(arenas);
+        }
+
+        fn createArena(self: *Self, prev_arena_batch: usize) ?*Arena {
+            const mutex = &self.mutex;
+            mutex.lock();
+
+            if (self.arenas != prev_arena_batch) {
+                mutex.unlock();
+                return self.getArena();
+            }
+
+            defer mutex.unlock();
+
+            const new_arenas = config.backing_allocator.alloc(Arena, config.shared_arena_batch_size) catch {
                 return null;
             };
 
-            self.arena_batch += 1;
+            self.arenas += config.shared_arena_batch_size;
 
-            for (new_arenas) |*new_arena| {
+            const first_arena = &new_arenas[0];
+            var prev_arena = first_arena;
+            prev_arena.* = Arena.init(.unlocked, null);
+
+            for (new_arenas[1..]) |*new_arena| {
                 new_arena.* = Arena.init(.unlocked, null);
+                prev_arena.next = new_arena;
+                prev_arena = new_arena;
             }
 
             new_arenas[0].makeMaster();
-            const acquired = acquireArena(&new_arenas[0], getThreadId());
+            const acquired = acquireArena(&new_arenas[0], getThreadId()).?;
 
-            assert(acquired != null);
+            if (self.last_arena) |*l_arena| {
+                l_arena.*.next = first_arena;
+                l_arena.* = first_arena;
+            }else{
+                self.first_arena = first_arena;
+                self.last_arena = first_arena;
+            }
 
-            for (new_arenas) |*new_arena| {
-                self.addArenaToList(new_arena);
+            if (config.shared_arena_batch_size > 1) {
+                self.free_arenas += config.shared_arena_batch_size - 1;
+                if (self.last_free_arena) |*lf_arena| {
+                    lf_arena.*.next = &new_arenas[1];
+                    lf_arena.* = prev_arena;
+                }else{
+                    self.first_free_arena = &new_arenas[1];
+                    self.last_free_arena = prev_arena;
+                }
             }
 
             return acquired;
         }
 
         fn addArenaToList(self: *Self, new_arena: *Arena) void {
-            if (self.arena_list == null) {
-                self.arena_list = new_arena;
+            if (self.first_arena == null) {
+                self.first_arena = new_arena;
 
                 return;
             }
 
-            var arena = self.arena_list.?;
-
-            while (arena.next) |next| {
-                arena = next;
-            }
-
+            const arena = self.last_arena.?;
             arena.next = new_arena;
+            self.last_arena = new_arena;
         }
 
         inline fn acquireArena(arena: *Arena, tid: std.Thread.Id) ?*Arena {

--- a/src/shared_arena_handler.zig
+++ b/src/shared_arena_handler.zig
@@ -5,7 +5,7 @@ const utils = @import("utils.zig");
 
 const JdzAllocConfig = jdz_allocator.JdzAllocConfig;
 
-const assert = std.debug.assert;
+const assert = utils.assert;
 
 const SlotState = enum {
     Available, Occupied

--- a/src/shared_arena_handler.zig
+++ b/src/shared_arena_handler.zig
@@ -121,7 +121,7 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
         }
 
         inline fn claimOrCreateArena(self: *Self, dispatcher: ArenaDispatcher) ?*Arena {
-            const index = dispatcher.index % dispatcher.capacity;
+            const index = dispatcher.index & (dispatcher.capacity - 1);
             const mod = index & batch_size_mask;
             const n_jumps = (index - mod) / config.shared_arena_batch_size;
 

--- a/src/shared_arena_handler.zig
+++ b/src/shared_arena_handler.zig
@@ -7,7 +7,8 @@ const JdzAllocConfig = jdz_allocator.JdzAllocConfig;
 
 const assert = utils.assert;
 
-var slots_counter: usize = 0;
+// Index 0 is reserved for comptime initialization (Only one instance can be created at comptime)
+var slots_counter: usize = 1; 
 pub const MAX_SLOTS = 256;
 
 var thread_aid_counter: [MAX_SLOTS]u64 = @splat(0);
@@ -16,7 +17,7 @@ const ArenaDispatcher = packed struct {
     index: u32,
     capacity: u32,
 };
-const dispatcher_max_index = std.math.maxInt(u32)/2;
+const dispatcher_max_index = std.math.maxInt(u32) / 2;
 
 pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
     // Verify batch size is power of two for optimization
@@ -34,7 +35,7 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
             pub fn init() ArenasSet {
                 var set: ArenasSet = .{
                     .arenas = undefined,
-                    .next = null
+                    .next = null,
                 };
 
                 for (&set.arenas) |*arena| {
@@ -55,17 +56,28 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
 
         const Self = @This();
 
-
         pub fn init() Self {
+            if (@inComptime()) {
+                // Only one instance can be created at comptime
+                return .{
+                    .first_arenas_set = ArenasSet.init(),
+                    .mutex = .{},
+                    .handler_slot = 0,
+                };
+            }
+
             const slot: usize = @atomicRmw(usize, &slots_counter, .Add, 1, .acquire);
             if (slot == MAX_SLOTS) {
                 // Maximum number of SharedArenaHandler instances has been reached.
-                // This implementation limits the total number of concurrent 
+                // This implementation limits the total number of concurrent
                 // JdzAllocator instances to MAX_SLOTS (256).
                 @panic("Maximum number of SharedArenaHandler instances exceeded");
             }
 
-            thread_aid_counter[slot] = @bitCast(ArenaDispatcher{.capacity = config.shared_arena_batch_size, .index = 0});
+            thread_aid_counter[slot] = @bitCast(ArenaDispatcher{
+                .capacity = config.shared_arena_batch_size,
+                .index = 0,
+            });
             return .{
                 .first_arenas_set = ArenasSet.init(),
                 .mutex = .{},
@@ -108,12 +120,22 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
             }
 
             const ptr = &thread_aid_counter[slot];
-            const prev_v = @atomicRmw(u64, ptr, .Add, @bitCast(ArenaDispatcher{.index = 1, .capacity = 0}), .acquire);
+            const prev_v = @atomicRmw(
+                u64,
+                ptr,
+                .Add,
+                @bitCast(ArenaDispatcher{ .index = 1, .capacity = 0 }),
+                .acq_rel,
+            );
             const dispatcher: ArenaDispatcher = @bitCast(prev_v);
 
             if (dispatcher.index == dispatcher_max_index) {
                 _ = @atomicRmw(
-                    u64, ptr, .Sub, @bitCast(ArenaDispatcher{.capacity = 0, .index = dispatcher_max_index}), .release
+                    u64,
+                    ptr,
+                    .Sub,
+                    @bitCast(ArenaDispatcher{ .capacity = 0, .index = dispatcher_max_index }),
+                    .release,
                 );
             }
 
@@ -121,20 +143,22 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
         }
 
         inline fn claimOrCreateArena(self: *Self, dispatcher: ArenaDispatcher) ?*Arena {
-            const index = dispatcher.index & (dispatcher.capacity - 1);
-            const mod = index & batch_size_mask;
-            const n_jumps = (index - mod) / config.shared_arena_batch_size;
+            if (dispatcher.capacity == 0) {
+                const index = dispatcher.index & (dispatcher.capacity - 1);
+                const mod = index & batch_size_mask;
+                const n_jumps = (index - mod) / config.shared_arena_batch_size;
 
-            var opt_arenas_set: *ArenasSet = &self.first_arenas_set;
-            for (0..n_jumps) |_| opt_arenas_set = opt_arenas_set.next.?;
+                var opt_arenas_set: *ArenasSet = &self.first_arenas_set;
+                for (0..n_jumps) |_| opt_arenas_set = opt_arenas_set.next.?;
 
-            const arena = &opt_arenas_set.arenas[mod];
-            if (!arena.tryAcquire()) {
-                return self.createArena();
+                const arena = &opt_arenas_set.arenas[mod];
+                if (arena.tryAcquire()) {
+                    cached_thread_arenas[self.handler_slot] = arena;
+                    return arena;
+                }
             }
 
-            cached_thread_arenas[self.handler_slot] = arena;
-            return arena;
+            return self.createArena();
         }
 
         fn createArena(self: *Self) ?*Arena {
@@ -161,9 +185,15 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
 
             const new_dispatcher = ArenaDispatcher{
                 .index = 0,
-                .capacity = config.shared_arena_batch_size
+                .capacity = config.shared_arena_batch_size,
             };
-            _ = @atomicRmw(u64, &thread_aid_counter[self.handler_slot], .Add, @bitCast(new_dispatcher), .release);
+            _ = @atomicRmw(
+                u64,
+                &thread_aid_counter[self.handler_slot],
+                .Add,
+                @bitCast(new_dispatcher),
+                .release,
+            );
 
             return arena;
         }

--- a/src/shared_arena_handler.zig
+++ b/src/shared_arena_handler.zig
@@ -66,7 +66,7 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
                 };
             }
 
-            const slot: usize = @atomicRmw(usize, &slots_counter, .Add, 1, .acquire);
+            const slot: usize = @atomicRmw(usize, &slots_counter, .Add, 1, .acq_rel);
             if (slot == MAX_SLOTS) {
                 // Maximum number of SharedArenaHandler instances has been reached.
                 // This implementation limits the total number of concurrent
@@ -143,7 +143,7 @@ pub fn SharedArenaHandler(comptime config: JdzAllocConfig) type {
         }
 
         inline fn claimOrCreateArena(self: *Self, dispatcher: ArenaDispatcher) ?*Arena {
-            if (dispatcher.capacity == 0) {
+            if (dispatcher.capacity > 0) {
                 const index = dispatcher.index & (dispatcher.capacity - 1);
                 const mod = index & batch_size_mask;
                 const n_jumps = (index - mod) / config.shared_arena_batch_size;

--- a/src/span.zig
+++ b/src/span.zig
@@ -21,21 +21,25 @@ const free_list_null = static_config.free_list_null;
 const invalid_pointer: usize = std.mem.alignBackward(usize, std.math.maxInt(usize), static_config.small_granularity);
 
 pub const Span = extern struct {
+    deferred_free_list: usize align(std.atomic.cache_line),
+
     free_list: usize,
-    full: bool,
-    aligned_blocks: bool,
-    block_count: u16,
-    class: SizeClass,
     span_count: usize,
-    arena: *anyopaque,
-    next: ?*Span,
-    prev: ?*Span,
     alloc_ptr: usize,
     initial_ptr: usize,
     alloc_size: usize,
 
-    deferred_free_list: usize align(std.atomic.cache_line),
+    class: SizeClass,
+
+    arena: *anyopaque,
+    next: ?*Span,
+    prev: ?*Span,
+
     deferred_frees: u16,
+    block_count: u16,
+
+    full: bool,
+    aligned_blocks: bool,
 
     pub inline fn pushFreeList(self: *Span, buf: []u8) void {
         const ptr = @call(.always_inline, Span.getBlockPtr, .{ self, buf });

--- a/src/span.zig
+++ b/src/span.zig
@@ -223,7 +223,7 @@ pub const Span = extern struct {
         const block: *usize = @ptrCast(@alignCast(ptr));
 
         while (true) {
-            block.* = @atomicRmw(usize, &self.deferred_free_list, .Xchg, invalid_pointer, .acquire);
+            block.* = @atomicRmw(usize, &self.deferred_free_list, .Xchg, invalid_pointer, .acq_rel);
 
             if (block.* != invalid_pointer) {
                 break;
@@ -241,7 +241,7 @@ pub const Span = extern struct {
         if (self.deferred_free_list == free_list_null) return false;
 
         while (true) {
-            self.free_list = @atomicRmw(usize, &self.deferred_free_list, .Xchg, invalid_pointer, .acquire);
+            self.free_list = @atomicRmw(usize, &self.deferred_free_list, .Xchg, invalid_pointer, .acq_rel);
 
             if (self.free_list != invalid_pointer) {
                 break;

--- a/src/span_cache.zig
+++ b/src/span_cache.zig
@@ -8,7 +8,7 @@ const span_file = @import("span.zig");
 
 const Span = span_file.Span;
 const testing = std.testing;
-const assert = std.debug.assert;
+const assert = utils.assert;
 const JdzAllocConfig = jdz_allocator.JdzAllocConfig;
 
 const span_size = static_config.span_size;

--- a/src/static_config.zig
+++ b/src/static_config.zig
@@ -22,7 +22,7 @@ pub const span_header_size = 256;
 pub const span_effective_size = span_size - span_header_size;
 pub const span_max = span_effective_size;
 
-pub const page_size = std.mem.page_size;
+pub const page_size = std.heap.pageSize();
 pub const mod_page_size = page_size - 1;
 pub const page_alignment = log2(page_size);
 

--- a/src/static_config.zig
+++ b/src/static_config.zig
@@ -22,7 +22,7 @@ pub const span_header_size = 256;
 pub const span_effective_size = span_size - span_header_size;
 pub const span_max = span_effective_size;
 
-pub const page_size = std.heap.pageSize();
+pub const page_size = std.heap.page_size_max;
 pub const mod_page_size = page_size - 1;
 pub const page_alignment = log2(page_size);
 

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 const jdz_allocator = @import("jdz_allocator.zig");
 const static_config = @import("static_config.zig");
@@ -12,8 +13,6 @@ const Span = span_file.Span;
 const Value = std.atomic.Value;
 const AtomicOrder = std.builtin.AtomicOrder;
 
-const assert = std.debug.assert;
-
 const usize_bits_subbed = @bitSizeOf(usize) - 1;
 
 const log2_usize_type = @Type(std.builtin.Type{ .Int = std.builtin.Type.Int{
@@ -25,6 +24,14 @@ const DummyMutex = struct {
     pub fn lock(_: @This()) void {}
     pub fn unlock(_: @This()) void {}
 };
+
+pub inline fn assert(ok: bool) void {
+    if ( builtin.mode != .Debug) {
+        if (!@inComptime()) return;
+    }
+
+    if (!ok) unreachable;
+}
 
 pub fn getMutexType(comptime config: JdzAllocConfig) type {
     return if (config.thread_safe)

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -21,7 +21,7 @@ const log2_usize_type = @Type(std.builtin.Type{ .Int = std.builtin.Type.Int{
 } });
 
 const DummyMutex = struct {
-    pub inline fn tryLock(_: @This()) void {}
+    pub inline fn tryLock(_: @This()) bool {}
     pub inline fn lock(_: @This()) void {}
     pub inline fn unlock(_: @This()) void {}
 };

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -21,8 +21,9 @@ const log2_usize_type = @Type(std.builtin.Type{ .Int = std.builtin.Type.Int{
 } });
 
 const DummyMutex = struct {
-    pub fn lock(_: @This()) void {}
-    pub fn unlock(_: @This()) void {}
+    pub inline fn tryLock(_: @This()) void {}
+    pub inline fn lock(_: @This()) void {}
+    pub inline fn unlock(_: @This()) void {}
 };
 
 pub inline fn assert(ok: bool) void {

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -21,7 +21,9 @@ const log2_usize_type = @Type(std.builtin.Type{ .Int = std.builtin.Type.Int{
 } });
 
 const DummyMutex = struct {
-    pub inline fn tryLock(_: @This()) bool {}
+    pub inline fn tryLock(_: @This()) bool {
+        return true;
+    }
     pub inline fn lock(_: @This()) void {}
     pub inline fn unlock(_: @This()) void {}
 };


### PR DESCRIPTION
Hello again :D

After my yesterday PR and your answer about finding a solution without using a mutex, I wanted to try if maybe... there is a way. And there is. In this new implementation of the Shared Allocator, we can get an existing arena without using a mutex. The mutex is being used only when we are creating a batch of arenas.

All the test cases have passed, and I also added 2 more. And the best thing is... the benchmarking test is showing that the Shared Allocator outperforms the Global Allocator (at least for mixed, small, and medium sizes).

I wrote this on another branch because maybe you want to take more time looking at these changes, meanwhile the others are more simple.